### PR TITLE
Add "configs" via flags passed as system properties to mod

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xmx1G
     loader_version=0.9.1+build.205
 
 # Mod Properties
-	mod_version = 1.2.0
+	mod_version = 1.3.0
 	maven_group = ai.arcblroth
 	archives_base_name = numberconfusion
 

--- a/src/main/java/ai/arcblroth/numberconfusion/Owo.java
+++ b/src/main/java/ai/arcblroth/numberconfusion/Owo.java
@@ -12,12 +12,12 @@ import java.util.Collections;
 
 public class Owo implements PrePreLaunch {
 
-    public static final boolean shuffleInts   = true;
-    public static final boolean shuffleBytes  = true;
-    public static final boolean shuffleShorts = true;
-    public static final boolean shuffleLongs  = true;
-    public static final boolean shuffleChars  = true;
-    public static final boolean swapBooleans  = true;
+    public static final boolean shuffleInts   = System.getProperty("numberconfusion.shuffleInts", "true").equals("true");    
+    public static final boolean shuffleBytes  = System.getProperty("numberconfusion.shuffleBytes", "true").equals("true");
+    public static final boolean shuffleShorts = System.getProperty("numberconfusion.shuffleShorts", "true").equals("true");
+    public static final boolean shuffleLongs  = System.getProperty("numberconfusion.shuffleLongs", "true").equals("true");
+    public static final boolean shuffleChars  = System.getProperty("numberconfusion.shuffleChars", "true").equals("true");
+    public static final boolean swapBooleans  = System.getProperty("numberconfusion.swapBooleans", "true").equals("true");
 
     @Override
     public void onPrePreLaunch() {


### PR DESCRIPTION
All options still default to true, although any string that isn't "true" will result in the boolean being set to false. 
Example config:

-Dnumberconfusion.shuffleInts=false -Dnumberconfusion.shuffleBytes=false -Dnumberconfusion.shuffleShorts=true -Dnumberconfusion.shuffleLongs=false -Dnumberconfusion.shuffleChars=false -Dnumberconfusion.swapBooleans=true

only enables shuffleShorts and swapBooleans.